### PR TITLE
Link user habits and goals to users

### DIFF
--- a/lib/features/habits/presentation/pages/add_habit_page.dart
+++ b/lib/features/habits/presentation/pages/add_habit_page.dart
@@ -7,6 +7,8 @@ import '../../../../core/constants/app_colors.dart';
 import '../../domain/entities/habit.dart';
 import '../cubit/habit_cubit.dart';
 import '../cubit/habit_state.dart';
+import '../../../authentication/presentation/cubit/auth_cubit.dart';
+import '../../../authentication/presentation/cubit/auth_state.dart';
 
 class AddHabitPage extends StatefulWidget {
   final Habit? habitToEdit; // For editing existing habits
@@ -526,17 +528,23 @@ class _AddHabitPageState extends State<AddHabitPage> {
       // context.read<HabitCubit>().updateHabit(updatedHabit);
     } else {
       // Create new habit
-      context.read<HabitCubit>().addHabit(
-        userId: 'current_user_id', // Replace with actual user ID
-        title: _titleController.text.trim(),
-        description: _descriptionController.text.trim().isEmpty 
-            ? null 
-            : _descriptionController.text.trim(),
-        category: _selectedCategory,
-        frequency: _selectedFrequency,
-        customDays: _selectedDays,
-        targetCount: _targetCount,
-      );
+      final authState = context.read<AuthCubit>().state;
+      if (authState is AuthAuthenticated) {
+        context.read<HabitCubit>().addHabit(
+          userId: authState.user.id,
+          title: _titleController.text.trim(),
+          description: _descriptionController.text.trim().isEmpty 
+              ? null 
+              : _descriptionController.text.trim(),
+          category: _selectedCategory,
+          frequency: _selectedFrequency,
+          customDays: _selectedDays,
+          targetCount: _targetCount,
+        );
+      } else {
+        _showErrorSnackBar('You must be logged in to create habits');
+        return;
+      }
     }
   }
 

--- a/lib/injection_container.dart
+++ b/lib/injection_container.dart
@@ -125,6 +125,7 @@ Future<void> init() async {
       remoteDataSource: sl(),
       localDataSource: sl(),
       networkInfo: sl(),
+      getCurrentUser: sl(),
     ),
   );
 


### PR DESCRIPTION
Connects habits to the authenticated user by replacing hardcoded user IDs to ensure user-specific data isolation.

Previously, the `HabitRepositoryImpl` and `AddHabitPage` used a static 'current_user_id', leading to all users sharing the same habit data. This PR injects the `GetCurrentUser` use case into the habit repository and retrieves the actual logged-in user's ID for all habit creation, retrieval, and update operations, ensuring each user has their own isolated habits.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d4e61e1-7b2a-4979-89dd-862f52ea13ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2d4e61e1-7b2a-4979-89dd-862f52ea13ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

