### PR TITLE
Fix habit completion and add habit type errors

### DIFF
--- a/lib/features/habits/domain/usecases/add_habit.dart
+++ b/lib/features/habits/domain/usecases/add_habit.dart
@@ -99,7 +99,7 @@ class AddHabit implements UseCase<Habit, AddHabitParams> {
           print('Current user stats: totalHabits=${userStats.totalHabits}, totalCompletions=${userStats.totalCompletions}');
           
           // Check for milestone achievements (like "First Step")
-          final newAchievements = await achievementRepository.checkAndUnlockAchievements(userId, {
+          final newAchievementsResult = await achievementRepository.checkAndUnlockAchievements(userId, {
             'totalHabits': totalHabits,
             'totalCompletions': userStats.totalCompletions,
             'currentStreak': userStats.currentStreak,
@@ -107,10 +107,17 @@ class AddHabit implements UseCase<Habit, AddHabitParams> {
             'activeHabits': totalHabits,
           });
           
-          print('Achievement check completed. New achievements unlocked: ${newAchievements.length}');
-          if (newAchievements.isNotEmpty) {
-            print('New achievements: ${newAchievements.map((a) => a.title).join(', ')}');
-          }
+          newAchievementsResult.fold(
+            (failure) {
+              print('Failed to check achievements: $failure');
+            },
+            (newAchievements) {
+              print('Achievement check completed. New achievements unlocked: ${newAchievements.length}');
+              if (newAchievements.isNotEmpty) {
+                print('New achievements: ${newAchievements.map((a) => a.title).join(', ')}');
+              }
+            },
+          );
         },
       );
     } catch (e) {

--- a/lib/features/habits/domain/usecases/complete_habit.dart
+++ b/lib/features/habits/domain/usecases/complete_habit.dart
@@ -99,7 +99,7 @@ class CompleteHabit implements UseCase<Habit, CompleteHabitParams> {
           print('Total completions after this completion: $totalCompletions');
           
           // Check for streak and completion achievements
-          final newAchievements = await achievementRepository.checkAndUnlockAchievements(userId, {
+          final newAchievementsResult = await achievementRepository.checkAndUnlockAchievements(userId, {
             'totalCompletions': totalCompletions,
             'currentStreak': completedHabit.currentStreak,
             'longestStreak': completedHabit.longestStreak,
@@ -109,10 +109,17 @@ class CompleteHabit implements UseCase<Habit, CompleteHabitParams> {
             'completionHour': DateTime.now().hour, // For early bird/night owl achievements
           });
           
-          print('Achievement check completed. New achievements unlocked: ${newAchievements.length}');
-          if (newAchievements.isNotEmpty) {
-            print('New achievements: ${newAchievements.map((a) => a.title).join(', ')}');
-          }
+          newAchievementsResult.fold(
+            (failure) {
+              print('Failed to check achievements: $failure');
+            },
+            (newAchievements) {
+              print('Achievement check completed. New achievements unlocked: ${newAchievements.length}');
+              if (newAchievements.isNotEmpty) {
+                print('New achievements: ${newAchievements.map((a) => a.title).join(', ')}');
+              }
+            },
+          );
         },
       );
     } catch (e) {


### PR DESCRIPTION
Handle `Either` type correctly when checking for achievements to fix `isNotEmpty` and `title` undefined getter errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-02ce9f90-4c95-4562-91b1-48526100aa20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-02ce9f90-4c95-4562-91b1-48526100aa20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

